### PR TITLE
add PostOrderProductData to Product

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zecko",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Zecko JS SDK",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -38,6 +38,7 @@ export type Product = {
   readonly variants: VariantEdges;
   readonly vendor: string;
   readonly metafields: MetaFieldEdges;
+  readonly postOrderProductData: PostOrderProductData;
 };
 
 export type ProductWrapper = {
@@ -65,3 +66,10 @@ export type ProductEdgesWrapper = {
 export type ProductsData = {
   readonly data: ProductEdgesWrapper;
 };
+
+export type PostOrderProductData = {
+  readonly returnDays: number;
+  readonly exchangeDays: number;
+  readonly cancelHours: number;
+  readonly brandReturnPolicyURL: string;
+}


### PR DESCRIPTION
This PR adds PostOrderProductData which includes returnDays, exchangeDays, brandReturnPolicyURL and cancelHours to Product
